### PR TITLE
Support of Minecraft 1.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Hunters and Runners
 
 This datapack is similar to Dream and GeorgeNotFounds manhunt/speedrunner vs videos<br/>
-Made for Java Edition 1.16+
+Made for Java Edition 1.17
 
 ## Download:
 https://github.com/RedSparr0w/hunters_and_runners/releases/latest/download/hunters_and_runners.zip

--- a/data/hunters_and_runners/functions/hunters/give_compass.mcfunction
+++ b/data/hunters_and_runners/functions/hunters/give_compass.mcfunction
@@ -1,6 +1,6 @@
 #> Give the hunters a compass to track players
 execute if data entity @s Inventory[{Slot:8b}] run give @s minecraft:compass{compass_type:"tracking_device",display:{Name:'[{"text":"Tracking Compass","italic":"false"}]',Lore:['{"text":"Detects players nearby.","color":"gray","italic": false}']},LodestoneTracked:0b}
-execute unless data entity @s Inventory[{Slot:8b}] run replaceitem entity @s hotbar.8 minecraft:compass{compass_type:"tracking_device",Enchantments:[{lvl:1,id:"minecraft:vanishing_curse"}],display:{Name:'[{"text":"Tracking Compass","italic":"false"}]',Lore:['{"text":"Detects players nearby.","color":"gray","italic": false}']},LodestoneTracked:0b}
+execute unless data entity @s Inventory[{Slot:8b}] run item replace entity @s hotbar.8 with minecraft:compass{compass_type:"tracking_device",Enchantments:[{lvl:1,id:"minecraft:vanishing_curse"}],display:{Name:'[{"text":"Tracking Compass","italic":"false"}]',Lore:['{"text":"Detects players nearby.","color":"gray","italic": false}']},LodestoneTracked:0b}
 
 tellraw @s [{"text":"===== Select Runner to track =====","color":"gold"}]
 tellraw @s [{"text":"[Nearest Runner]","color":"aqua","clickEvent":{"action":"run_command","value":"/trigger hnr.tracking_id set 0"},"hoverEvent":{"action":"show_text","value":{"text":"Track the nearest runner!"}}}]

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,6 +1,6 @@
 {
    "pack": {
-      "pack_format": 5,
+      "pack_format": 7,
       "description": "Hunters and Runners by RedSparr0w#0167"
    }
 }


### PR DESCRIPTION
1. Replace the command "replaceitem" with "item", made it useable in Minecraft 1.17(20w46a+).
2. Removed support of Minecraft 1.16.x(because of command changes).